### PR TITLE
fix: remove 422 IDENTIFIER MISMATCH

### DIFF
--- a/code/API_definitions/connectivity-insights.yaml
+++ b/code/API_definitions/connectivity-insights.yaml
@@ -585,12 +585,6 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorInfo"
           examples:
-            GENERIC_422_IDENTIFIER_MISMATCH:
-              description: Inconsistency between device identifiers not pointing to the same device
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service is not available for the provided device
               value:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction



#### What this PR does / why we need it:

Remove `422 IDENTIFIER MISMATCH` as per Commonalities r32


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #139 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
