### PR TITLE
Reset versions in API and test definitions back to wip after r3.1

### DIFF
--- a/code/API_definitions/connectivity-insights-subscriptions.yaml
+++ b/code/API_definitions/connectivity-insights-subscriptions.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Connectivity Insights Subscriptions
-  version: 0.6.0-rc.1
+  version: wip
   x-camara-commonalities: 0.6
   description: |
     With CAMARA Connectivity Insights, application developers gain essential
@@ -146,7 +146,7 @@ externalDocs:
   url: https://github.com/camaraproject/ConnectivityInsights/
 
 servers:
-  - url: "{apiRoot}/connectivity-insights-subscriptions/v0.6rc1"
+  - url: "{apiRoot}/connectivity-insights-subscriptions/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/connectivity-insights.yaml
+++ b/code/API_definitions/connectivity-insights.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Connectivity Insights
-  version: 0.6.0-rc.1
+  version: wip
   x-camara-commonalities: 0.6
   description: |
     With CAMARA Connectivity Insights, application developers gain essential
@@ -100,7 +100,7 @@ externalDocs:
   url: https://github.com/camaraproject/ConnectivityInsights
 
 servers:
-  - url: "{apiRoot}/connectivity-insights/v0.6rc1"
+  - url: "{apiRoot}/connectivity-insights/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/Test_definitions/connectivity-insights-subscriptions.feature
+++ b/code/Test_definitions/connectivity-insights-subscriptions.feature
@@ -1,10 +1,10 @@
-Feature: CAMARA Connectivity Insights Subscriptions API, v0.6.0-rc.1 - Operations for Subscriptions
+Feature: CAMARA Connectivity Insights Subscriptions API, vwip - Operations for Subscriptions
 
 # Input to be provided by the implementation to the tests
 # References to OAS spec schemas refer to schemas specified in connectivity-insights-subscriptions.yaml
 
   Background: Common Connectivity Insights Subscriptions setup
-    Given the resource "{apiroot}/connectivity-insights-subscriptions/v0.6rc1" as base-url
+    Given the resource "{apiroot}/connectivity-insights-subscriptions/vwip" as base-url
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/connectivity-insights.feature
+++ b/code/Test_definitions/connectivity-insights.feature
@@ -1,10 +1,10 @@
-Feature: CAMARA Connectivity Insights API, v0.6.0-rc.1 - Operations for Network Quality
+Feature: CAMARA Connectivity Insights API, vwip - Operations for Network Quality
 
 # Input to be provided by the implementation to the tests
 # References to OAS spec schemas refer to schemas specified in connectivity-insights.yaml
 
   Background: Common Connectivity Insights setup
-    Given the resource "{apiroot}/connectivity-insights/v0.6rc1" as base-url
+    Given the resource "{apiroot}/connectivity-insights/vwip" as base-url
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* subproject management


#### What this PR does / why we need it:
Setting the version in API and test definitions back to wip after r3.1 to clearly indicate that any change done between r3.1 and r3.2 does not belong to neither of the releases.
