### PR TITLE
fix(release-plan): set Connectivity Insights API status to rc

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -34,14 +34,14 @@ dependencies:
 apis:
   - api_name: connectivity-insights-subscriptions
     target_api_version: 0.7.0
-    target_api_status: public
+    target_api_status: rc
     main_contacts:
       - maheshc01
       - kevsy
       - urvika-v
   - api_name: connectivity-insights
     target_api_version: 0.7.0
-    target_api_status: public
+    target_api_status: rc
     main_contacts:
       - maheshc01
       - kevsy


### PR DESCRIPTION
fix(release-plan): set Connectivity Insights API status to rc

#### What type of PR is this?

correction

#### What this PR does / why we need it:

Sets both Connectivity Insights APIs to target_api_status: rc in release-plan.yaml.

This avoids applying public-release validation severity while the repository is preparing the r4.3 sync. The current sync PR #190 is failing strict info.description validation because the APIs are already marked public.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

This is intended to unblock the Commonalities r4.3 sync PR #190. The API versions and repository target release type are unchanged.

#### Changelog input

```
 release-note

```

#### Additional documentation

This section can be blank.


```
docs

```
