### PR TITLE
fix(api): add missing schema object types

### DIFF
--- a/code/API_definitions/connectivity-insights-subscriptions.yaml
+++ b/code/API_definitions/connectivity-insights-subscriptions.yaml
@@ -872,6 +872,7 @@ components:
       example: "https://notificationSendServer12.supertelco.com"
     CloudEvent:
       description: The Cloud-Event used for the callback.
+      type: object
       required:
         - id
         - source

--- a/code/API_definitions/connectivity-insights.yaml
+++ b/code/API_definitions/connectivity-insights.yaml
@@ -422,6 +422,7 @@ components:
     DeviceResponseBody:
       description: |
         The optional device identifier to include in the response
+      type: object
       properties:
         device:
           description: |


### PR DESCRIPTION
fix(api): add missing schema object types

#### What type of PR is this?

correction

#### What this PR does / why we need it:

Adds the missing object type declarations for CloudEvent and DeviceResponseBody.

This clears the two remaining S-016 validation errors currently blocking the Commonalities r4.3 sync PR #190.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

Suggested sequence:

1. Approve and merge this PR.
2. Resync #192 with main, approve and merge.
3. Resync #190 with main, approve and merge.

#### Changelog input

```
 release-note

```

#### Additional documentation

This section can be blank.


```
docs

```
