### PR TITLE
fix: connectivity-insights-subscriptions schema fixes from release review

### DIFF
--- a/code/API_definitions/connectivity-insights-subscriptions.yaml
+++ b/code/API_definitions/connectivity-insights-subscriptions.yaml
@@ -550,7 +550,8 @@ components:
 
     ApplicationServerIpv4Address:
       type: string
-      maxLength: 49
+      maxLength: 18
+      pattern: '^([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])(\.([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])){3}(\/(3[0-2]|[12]?[0-9]))?$'
       example: "192.168.0.1/24"
       description: |
         IPv4 address may be specified in form <address/mask> as:
@@ -563,7 +564,8 @@ components:
 
     ApplicationServerIpv6Address:
       type: string
-      maxLength: 50
+      maxLength: 49
+      pattern: '^[0-9a-fA-F:.]+(\/(12[0-8]|1[0-1][0-9]|[1-9]?[0-9]))?$'
       example: "2001:db8:85a3:8d3:1319:8a2e:370:7344"
       description: |
         IPv6 address may be specified in form <address/mask> as:

--- a/code/API_definitions/connectivity-insights-subscriptions.yaml
+++ b/code/API_definitions/connectivity-insights-subscriptions.yaml
@@ -626,7 +626,7 @@ components:
         applicationProfileId:
           $ref: "#/components/schemas/ApplicationProfileId"
       required:
-        - device
+        - applicationServer
         - applicationProfileId
 
     SubscriptionRequest:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction



#### What this PR does / why we need it:

Fixes two schema issues identified in connectivity-insights-subscriptions:

1. correct maxLength and patterns are now added for ApplicationServerIpv4Address and ApplicationServerIpv6Address
2. changes the required properties expected in the `CreateSubscriptionDetail` schema


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #206 #208 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
